### PR TITLE
Add internet gateway module and integrate it into main.tf

### DIFF
--- a/aws/internetgateway/main.tf
+++ b/aws/internetgateway/main.tf
@@ -1,0 +1,7 @@
+resource "aws_internet_gateway" "this" {
+  vpc_id = var.vpc_id
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/aws/internetgateway/variables.tf
+++ b/aws/internetgateway/variables.tf
@@ -1,0 +1,9 @@
+variable "vpc_id" {
+  description = "VPC ID where the internet gateway will be created"
+  type        = string
+}
+
+variable "name" {
+  description = "Name tag for the internet gateway"
+  type        = string
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -11,3 +11,9 @@ module "subnet" {
   vpc_id            = module.vpc.vpc_id
   availability_zone = "ap-northeast-1a"
 }
+
+module "internet_gateway" {
+  source = "./internetgateway"
+  vpc_id = module.vpc.vpc_id
+  name   = "test-internet-gateway"
+}


### PR DESCRIPTION
This pull request introduces a new reusable Terraform module for creating an AWS Internet Gateway and integrates it into the main infrastructure configuration. The changes improve modularity and make it easier to manage Internet Gateway resources in the future.

**Internet Gateway module creation and integration:**

* Added a new Terraform resource `aws_internet_gateway.this` in `aws/internetgateway/main.tf` to provision an Internet Gateway attached to a specified VPC, with support for naming via tags.
* Defined input variables `vpc_id` and `name` in `aws/internetgateway/variables.tf` to parameterize the Internet Gateway module.
* Integrated the new `internet_gateway` module into the main Terraform configuration in `aws/main.tf`, passing in the VPC ID and a name for the gateway.