### PR TITLE
Add public route table module and integrate it into main.tf, includin…

### DIFF
--- a/aws/internetgateway/output.tf
+++ b/aws/internetgateway/output.tf
@@ -1,0 +1,4 @@
+output "gateway_id" {
+  description = "ID of the created internet gateway"
+  value       = aws_internet_gateway.this.id
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -17,3 +17,11 @@ module "internet_gateway" {
   vpc_id = module.vpc.vpc_id
   name   = "test-internet-gateway"
 }
+
+module "public_route_table" {
+  source     = "./route_table"
+  vpc_id     = module.vpc.vpc_id
+  cidr_block = "0.0.0.0/0"
+  gateway_id = module.internet_gateway.gateway_id
+  name       = "public-route-table"
+}

--- a/aws/route_table/main.tf
+++ b/aws/route_table/main.tf
@@ -1,0 +1,12 @@
+resource "aws_route_table" "this" {
+  vpc_id = var.vpc_id
+
+  route {
+    cidr_block = var.cidr_block
+    gateway_id = var.gateway_id
+  }
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/aws/route_table/variable.tf
+++ b/aws/route_table/variable.tf
@@ -1,0 +1,20 @@
+variable "vpc_id" {
+  description = "VPC ID where the public route table will be created"
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the public route table"
+  type        = string
+}
+
+variable "gateway_id" {
+  description = "Gateway ID for the public route table"
+  type        = string
+}
+
+variable "name" {
+  description = "Name tag for the public route table"
+  type        = string
+}
+


### PR DESCRIPTION
This pull request adds a new Terraform module for managing a public route table and integrates it with the existing VPC and Internet Gateway setup. The changes ensure that a route is created for outbound internet access through the Internet Gateway and make the new resources configurable and reusable.

**New Public Route Table Module:**

* Added a new `aws_route_table` resource in `aws/route_table/main.tf` to create a route table with a route to the internet via the specified gateway.
* Introduced input variables for the route table module in `aws/route_table/variable.tf`, making it configurable for VPC ID, CIDR block, gateway ID, and name.

**Integration with Main Infrastructure:**

* Added a `public_route_table` module block to `aws/main.tf` that creates a public route table using the new module, passing in the VPC ID, CIDR block, Internet Gateway ID, and a name.
* Exposed the Internet Gateway's ID as an output in `aws/internetgateway/output.tf` to allow other modules (like the route table) to reference it.…g necessary variables and outputs for the internet gateway.